### PR TITLE
Add leaf pkgListURL support

### DIFF
--- a/branchbuildbot/src/buildenvmanager/buildenv.py
+++ b/branchbuildbot/src/buildenvmanager/buildenv.py
@@ -24,7 +24,7 @@ def init_leafcore():
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_NOASK, True)
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_FORCEOVERWRITE, True)
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_NOPROGRESS, True)
-    leafcore_instance.setStringConfig(pyleafcore.LeafConfig_string.CONFIG_PKGLISTURL, config.branch_options.leafserveraddr)
+    leafcore_instance.setStringConfig(pyleafcore.LeafConfig_string.CONFIG_PKGLISTURL, config.branch_options.leafserveraddr + "/?get=packagelist")
     blog.debug("Leafcore initialized.")
     return 0
 

--- a/branchbuildbot/src/buildenvmanager/buildenv.py
+++ b/branchbuildbot/src/buildenvmanager/buildenv.py
@@ -6,6 +6,7 @@ from log import blog
 from pyleaf import pyleafcore
 from pathlib import Path
 from buildenvmanager import buildenv
+from config import config
 
 LAUNCH_DIR = os.getcwd()
 leafcore_instance = None
@@ -23,6 +24,7 @@ def init_leafcore():
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_NOASK, True)
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_FORCEOVERWRITE, True)
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_NOPROGRESS, True)
+    leafcore_instance.setStringConfig(pyleafcore.LeafConfig_string.CONFIG_PKGLISTURL, config.branch_options.leafserveraddr)
     blog.debug("Leafcore initialized.")
     return 0
 

--- a/branchbuildbot/src/buildenvmanager/buildenv.py
+++ b/branchbuildbot/src/buildenvmanager/buildenv.py
@@ -24,7 +24,7 @@ def init_leafcore():
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_NOASK, True)
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_FORCEOVERWRITE, True)
     leafcore_instance.setBoolConfig(pyleafcore.LeafConfig_bool.CONFIG_NOPROGRESS, True)
-    leafcore_instance.setStringConfig(pyleafcore.LeafConfig_string.CONFIG_PKGLISTURL, config.branch_options.leafserveraddr + "/?get=packagelist")
+    leafcore_instance.setStringConfig(pyleafcore.LeafConfig_string.CONFIG_PKGLISTURL, config.branch_options.leafpkglisturl)
     blog.debug("Leafcore initialized.")
     return 0
 

--- a/branchbuildbot/src/config/config.py
+++ b/branchbuildbot/src/config/config.py
@@ -6,6 +6,7 @@ from log import blog
 class branch_options():
     serverport = 27015
     serveraddr = "127.0.0.1"
+    leafserveraddr = "http://127.0.0.1/?get=packagelist"
     debuglog = False
     authkey = ""
     identifier = ""
@@ -47,6 +48,8 @@ class branch_options():
                 branch_options.serveraddr = val
             elif(key == "serverport"):
                 branch_options.serverport = int(val)
+            elif(key == "leafserveraddr"):
+                branch_options.leafserveraddr = val
             elif(key == "debuglog"):
                 if(val == "False"):
                     branch_options.debuglog = False
@@ -88,6 +91,9 @@ class branch_options():
         branch_cfg.write("# IP address and port of the masterserver:\n")
         branch_cfg.write("serveraddr=127.0.0.1\n")
         branch_cfg.write("serverport=27015\n")
+
+        branch_cfg.write("# URL leaf should use to retrieve its packagelist\n")
+        branch_cfg.write("leafserveraddr=http://127.0.0.1/?get=packagelist\n")
 
         branch_cfg.write("# Print Debug log messages:\n")
         branch_cfg.write("debuglog=False\n")

--- a/branchbuildbot/src/config/config.py
+++ b/branchbuildbot/src/config/config.py
@@ -6,7 +6,7 @@ from log import blog
 class branch_options():
     serverport = 27015
     serveraddr = "127.0.0.1"
-    leafserveraddr = "http://127.0.0.1"
+    leafpkglisturl = "http://127.0.0.1/?get=packagelist"
     debuglog = False
     authkey = ""
     identifier = ""
@@ -48,8 +48,8 @@ class branch_options():
                 branch_options.serveraddr = val
             elif(key == "serverport"):
                 branch_options.serverport = int(val)
-            elif(key == "leafserveraddr"):
-                branch_options.leafserveraddr = val
+            elif(key == "leafpkglisturl"):
+                branch_options.leafpkglisturl = val
             elif(key == "debuglog"):
                 if(val == "False"):
                     branch_options.debuglog = False
@@ -93,7 +93,7 @@ class branch_options():
         branch_cfg.write("serverport=27015\n")
 
         branch_cfg.write("# URL leaf should use to retrieve its packagelist\n")
-        branch_cfg.write("leafserveraddr=http://127.0.0.1\n")
+        branch_cfg.write("leafpkglisturl=http://127.0.0.1/?get=packagelist\n")
 
         branch_cfg.write("# Print Debug log messages:\n")
         branch_cfg.write("debuglog=False\n")

--- a/branchbuildbot/src/config/config.py
+++ b/branchbuildbot/src/config/config.py
@@ -6,7 +6,7 @@ from log import blog
 class branch_options():
     serverport = 27015
     serveraddr = "127.0.0.1"
-    leafserveraddr = "http://127.0.0.1/?get=packagelist"
+    leafserveraddr = "http://127.0.0.1"
     debuglog = False
     authkey = ""
     identifier = ""
@@ -93,7 +93,7 @@ class branch_options():
         branch_cfg.write("serverport=27015\n")
 
         branch_cfg.write("# URL leaf should use to retrieve its packagelist\n")
-        branch_cfg.write("leafserveraddr=http://127.0.0.1/?get=packagelist\n")
+        branch_cfg.write("leafserveraddr=http://127.0.0.1\n")
 
         branch_cfg.write("# Print Debug log messages:\n")
         branch_cfg.write("debuglog=False\n")


### PR DESCRIPTION
The `branchbuildbot` config file can now specify the server address `leaf` should retrieve its packagelist from