### PR TITLE
Add findutils as a base build dependency

### DIFF
--- a/branchbuildbot/src/buildenvmanager/buildenv.py
+++ b/branchbuildbot/src/buildenvmanager/buildenv.py
@@ -132,7 +132,7 @@ def deploy_buildenv(root_dir, diff_dir, work_dir, temp_dir):
         blog.error("Leaf error code: {}".format(leaf_error))
         return -1
 
-    pkgs = ["base", "glibc", "gcc", "make", "bash", "sed", "grep", "gawk", "coreutils", "binutils", "automake", "autoconf", "file", "gzip", "libtool", "m4", "groff", "patch", "texinfo", "which"]
+    pkgs = ["base", "glibc", "gcc", "make", "bash", "sed", "grep", "gawk", "coreutils", "binutils", "findutils", "automake", "autoconf", "file", "gzip", "libtool", "m4", "groff", "patch", "texinfo", "which"]
 
     leaf_error = leafcore_instance.a_install(pkgs)
     if(leaf_error != 0):


### PR DESCRIPTION
The `findutils` package is needed by a lot of packages to build, so it should be added to the preinstalled build packages.